### PR TITLE
Run the performance test overnight

### DIFF
--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -1,0 +1,20 @@
+#!groovy
+
+String product = 'div'
+String component = 'pfe'
+
+// execute nightly at 9:00 PM
+properties([
+        parameters([string(name: 'ENVIRONMENT', defaultValue: 'aat', description: 'Environment to test')]),
+        parameters([string(name: 'TEST_URL', defaultValue: 'https://div-pfe-aat.service.core-compute-aat.internal', description: 'Base URL of the environment to test')]),
+        pipelineTriggers([cron('H 21 * * *')])
+])
+
+// parameters are: product, component, environment
+withPerformanceTest(product, component, params.ENVIRONMENT) {
+
+    // Set target URL
+    before('performancetest') {
+        env.TEST_URL = params.TEST_URL
+    }
+}

--- a/results/.gitignore
+++ b/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/test/scala/scenarios/BasicDivorce.scala
+++ b/src/test/scala/scenarios/BasicDivorce.scala
@@ -10,7 +10,7 @@ import simulations.divorce._
 object BasicDivorce {
 
   val conf = ConfigFactory.load()
-  val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+  val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
   val idamBaseUrl = scala.util.Properties.envOrElse("IDAM_URL", conf.getString("idamBaseUrl")).toLowerCase()
   val feeder = csv("upload_docs.csv").random
   val addIdamUserUrl = idamBaseUrl + "/testing-support/accounts"

--- a/src/test/scala/scenarios/BasicDivorceNotCompleted.scala
+++ b/src/test/scala/scenarios/BasicDivorceNotCompleted.scala
@@ -9,7 +9,7 @@ import simulations.divorce._
 object BasicDivorceNotCompleted {
 
   val conf = ConfigFactory.load()
-  val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+  val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
   val idamBaseUrl = scala.util.Properties.envOrElse("IDAM_URL", conf.getString("idamBaseUrl")).toLowerCase()
   val addIdamUserUrl = idamBaseUrl + "/testing-support/accounts"
   val continuePause = conf.getInt("continuePause")

--- a/src/test/scala/scenarios/BasicDivorceWithPayment.scala
+++ b/src/test/scala/scenarios/BasicDivorceWithPayment.scala
@@ -9,7 +9,7 @@ import simulations.divorce._
 object BasicDivorceWithPayment {
 
   val conf = ConfigFactory.load()
-  val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+  val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
   val idamBaseUrl = scala.util.Properties.envOrElse("IDAM_URL", conf.getString("idamBaseUrl")).toLowerCase()
   val feeder = csv("upload_docs.csv").random
   val addIdamUserUrl = idamBaseUrl + "/testing-support/accounts"

--- a/src/test/scala/simulations/Divorce.scala
+++ b/src/test/scala/simulations/Divorce.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable.ArrayBuffer
 class Divorce extends Simulation
     with HttpConfiguration {
     val conf = ConfigFactory.load()
-    val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+    val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
     val httpconf = httpProtocol.baseURL(baseurl).disableCaching
     val continuePause = conf.getInt("continuePause")
     val userCount = conf.getInt("users")

--- a/src/test/scala/simulations/divorce/AboutDivorce.scala
+++ b/src/test/scala/simulations/divorce/AboutDivorce.scala
@@ -9,7 +9,7 @@ import simulations.checks.CsrfCheck.{csrfParameter, csrfTemplate}
 object AboutDivorce {
 
     val conf = ConfigFactory.load()
-    val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+    val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
     val continuePause = conf.getInt("continuePause")
 
     val legalProceedings = exec(http("DIV01_370_About-Divorce_Legal-Proceedings")

--- a/src/test/scala/simulations/divorce/AboutYourMarriage.scala
+++ b/src/test/scala/simulations/divorce/AboutYourMarriage.scala
@@ -9,7 +9,7 @@ import simulations.checks.CsrfCheck.{csrfParameter, csrfTemplate}
 object AboutYourMarriage {
 
     val conf = ConfigFactory.load()
-    val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+    val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
     val continuePause = conf.getInt("continuePause")
 
     val details = exec(http("DIV01_080_AboutMarriageDetails")

--- a/src/test/scala/simulations/divorce/CheckYourAnswers.scala
+++ b/src/test/scala/simulations/divorce/CheckYourAnswers.scala
@@ -8,7 +8,7 @@ import simulations.checks.CsrfCheck.{csrfParameter, csrfTemplate}
 object CheckYourAnswers {
 
     val conf = ConfigFactory.load()
-    val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+    val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
     val continuePause = conf.getInt("continuePause")
 
   val confirm = exec(http("DIV01_430_Check-Your-Answers")

--- a/src/test/scala/simulations/divorce/HomePage.scala
+++ b/src/test/scala/simulations/divorce/HomePage.scala
@@ -7,7 +7,7 @@ import com.typesafe.config._
 object HomePage {
 
     val conf = ConfigFactory.load()
-    val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+    val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
     val continuePause = conf.getInt("continuePause")
 
     val startDivorce = exec(http("DIV01_010_StartPage")

--- a/src/test/scala/simulations/divorce/Idam.scala
+++ b/src/test/scala/simulations/divorce/Idam.scala
@@ -10,7 +10,7 @@ import simulations.checks.CsrfCheck
 object Idam {
 
     val conf = ConfigFactory.load()
-    val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+    val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
     val idamBaseUrl = scala.util.Properties.envOrElse("IDAM_URL", conf.getString("idamBaseUrl")).toLowerCase()
     val continuePause = conf.getInt("continuePause")
 

--- a/src/test/scala/simulations/divorce/Jurisdiction.scala
+++ b/src/test/scala/simulations/divorce/Jurisdiction.scala
@@ -10,7 +10,7 @@ import simulations.divorce.AboutYourMarriage.conf
 object Jurisdiction {
 
     val conf = ConfigFactory.load()
-    val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+    val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
     val continuePause = conf.getInt("continuePause")
 
     val habitualResidence = exec(http("DIV01_130_HabitualResidence")

--- a/src/test/scala/simulations/divorce/Pay.scala
+++ b/src/test/scala/simulations/divorce/Pay.scala
@@ -12,7 +12,7 @@ import simulations.checks.{CsrfCheck, CsrfCheckForPayment, CurrentPageUrl, Payme
 object Pay {
 
     val conf = ConfigFactory.load()
-    val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+    val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
     val continuePause = conf.getInt("continuePause")
 
     val needHelpWithFeesNo = exec(http("DIV_60_NeedHelpWithFeesNo")

--- a/src/test/scala/simulations/divorce/PetitionerRespondent.scala
+++ b/src/test/scala/simulations/divorce/PetitionerRespondent.scala
@@ -9,7 +9,7 @@ import simulations.checks.CsrfCheck.{csrfParameter, csrfTemplate}
 object PetitionerRespondent {
 
     val conf = ConfigFactory.load()
-    val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+    val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
     val continuePause = conf.getInt("continuePause")
 
     val confidentialPetitionerDetails = exec(http("DIV01_170_Confidential")

--- a/src/test/scala/simulations/divorce/Public.scala
+++ b/src/test/scala/simulations/divorce/Public.scala
@@ -7,7 +7,7 @@ import com.typesafe.config._
 object Public {
 
     val conf = ConfigFactory.load()
-    val baseurl: String = System.getenv("E2E_FRONTEND_URL")
+    val baseurl: String = System.getenv("TEST_URL")
     val continuePause = conf.getInt("continuePause")
 
     val indexPage = exec(http(" DIV01_005_LandingPage")

--- a/src/test/scala/simulations/divorce/ReasonForDivorce.scala
+++ b/src/test/scala/simulations/divorce/ReasonForDivorce.scala
@@ -9,7 +9,7 @@ import simulations.checks.CsrfCheck.{csrfParameter, csrfTemplate}
 object ReasonForDivorce {
 
     val conf = ConfigFactory.load()
-    val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+    val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
     val continuePause = conf.getInt("continuePause")
 
     val reason = exec(http("DIV01_280_ReasonForDivorce")

--- a/src/test/scala/simulations/divorce/ScreeningQuestions.scala
+++ b/src/test/scala/simulations/divorce/ScreeningQuestions.scala
@@ -9,7 +9,7 @@ import simulations.checks.CsrfCheck.{csrfParameter, csrfTemplate}
 object ScreeningQuestions {
 
     val conf = ConfigFactory.load()
-    val baseurl = scala.util.Properties.envOrElse("E2E_FRONTEND_URL", conf.getString("baseUrl")).toLowerCase()
+    val baseurl = scala.util.Properties.envOrElse("TEST_URL", conf.getString("baseUrl")).toLowerCase()
     val continuePause = conf.getInt("continuePause")
 
     val hasMarriageBroken = exec(http("DIV01_030_HasYourMarriageBroken")


### PR DESCRIPTION
#### JIRA link (if applicable)

https://tools.hmcts.net/jira/browse/DIV-2883

#### Change description

This change incorporates the CNP functionality to run performance tests overnight.

#### How is the change implemented?

This has been done by configuring a Jenkinsfile that uses the `withPerformanceTest()' pipeline to run a parameterised overnight job at 9:00 pm.

#### Work checklist

- [x] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added if needed
- [ ] Tests have been updated / new tests has been added if needed